### PR TITLE
Add (temporary) fix for OneCRL-Tools / Cargo issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ ENV PORT 8000
 ENV FLASK_ENV "production"
 ENV SQLALCHEMY_DATABASE_URI postgresql+psycopg2://pguser:pgpass@pghost/dbname
 ENV CELERY_BROKER_URL sqla+postgresql://pguser:pgpass@pghost/dbname
+ENV OPENSSL_INCLUDE_DIR /usr/include/openssl
+ENV OPENSSL_LIB_DIR /usr/lib/x86_64-linux-gnu
 
 RUN groupadd --gid 10001 app && \
     useradd --uid 10001 --gid 10001 --shell /usr/sbin/nologin app
@@ -19,7 +21,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
             ca-certificates \
             build-essential \
             curl \
-            libpq-dev
+            libssl-dev \
+            libpq-dev \
+            firefox-esr \
+            git
 
 WORKDIR /app
 
@@ -30,6 +35,10 @@ RUN curl -o /opt/wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait
       chmod +x /opt/wait-for-it.sh
 
 USER app
+
+RUN mkdir /tmp/rust
+ENV HOME /tmp/rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup.sh && sh /tmp/rustup.sh -y 
 
 ENTRYPOINT [ ]
 CMD ["gunicorn", "--chdir", "src", "src.web.wsgi:app"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - db
     command:
       [
-         "celery", "worker", "--app=src.tasks.tasks"
+        "sh", "/app/scripts/worker.sh"
       ]
 
   db-migration:

--- a/requirements/defaults.txt
+++ b/requirements/defaults.txt
@@ -26,4 +26,4 @@ toml==0.10.0
 typed-ast==1.4.1
 Werkzeug==1.0.1
 wrapt==1.11.2
-tlscanary==4.0.0
+tlscanary==4.0.1a2

--- a/scripts/worker.sh
+++ b/scripts/worker.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+PATH=$PATH:/tmp/rust/.cargo/bin
+celery worker --app=src.tasks.tasks

--- a/src/tasks/tasks.py
+++ b/src/tasks/tasks.py
@@ -125,7 +125,8 @@ class SymantecJob(object):
                "-t", "beta",
                "-p1", "security.pki.distrust_ca_policy;2",
                "-b", "beta",
-               "-p2", "security.pki.distrust_ca_policy;0"
+               "-p2", "security.pki.distrust_ca_policy;0",
+               "--onecrlpin", "20200604-issue-157",
                ]
         log.info("Running `%s`" % " ".join(cmd))
         run(cmd, check=True)
@@ -255,7 +256,8 @@ class TLSDeprecationJob(object):
                "-t", "beta",
                "-p1", "security.tls.version.min;3",
                "-b", "beta",
-               "-p2", "security.tls.version.min;1"
+               "-p2", "security.tls.version.min;1",
+               "--onecrlpin", "20200604-issue-157",
                ]
         log.info("Running `%s`" % " ".join(cmd))
         run(cmd, check=True)
@@ -348,7 +350,7 @@ class SrcUpdateJob(object):
     def run(self):
         log.info("Updating sources")
         # Setting distrust policy to 0 as long as we need to capture hosts for Symantec regressions
-        cmd = [self.tlscanary_binary, "-w", "/tmp/workdir", "srcupdate", "-p", "security.pki.distrust_ca_policy;0"]
+        cmd = [self.tlscanary_binary, "-w", "/tmp/workdir", "srcupdate", "-p", "security.pki.distrust_ca_policy;0", "--onecrlpin", "20200604-issue-157"]
         log.info("Running `%s`" % " ".join(cmd))
         run(cmd, check=True)
         log.info("Completed source update job")


### PR DESCRIPTION
There are (were) some issues related to tls-canary and OneCRL-Tools. I've made PRs to both OneCRL-Tools and tls-canary to resolve these issues; this PR ensures tlscs-dockerflow uses fixed versions and that the relevant tooling build cleanly on the tlscs-dockerflow-worker container.